### PR TITLE
Instant startup

### DIFF
--- a/membership_dashboard.py
+++ b/membership_dashboard.py
@@ -6,7 +6,8 @@ import plotly.graph_objects as go
 import dash_bootstrap_components as dbc
 from dash_bootstrap_templates import load_figure_template
 from dash import Dash, html, dash_table, dcc, callback, clientside_callback, Output, Input
-from scan_membership_lists import scan_all_membership_lists
+from scan_membership_lists import get_all_membership_lists, get_membership_list_metrics
+#from scan_membership_lists import scan_all_membership_lists, scan_membership_list_metrics
 
 
 # A list of colors for graphs.
@@ -27,7 +28,8 @@ COLORS = [
 ]
 
 
-memb_lists, memb_lists_metrics = scan_all_membership_lists()
+memb_lists = get_all_membership_lists()
+memb_lists_metrics = get_membership_list_metrics()
 
 
 # Initialize the app
@@ -168,8 +170,8 @@ member_list_page = html.Div(
             ],
             filter_action="native",
             filter_options={
-				"case": "insensitive"
-			},
+                "case": "insensitive"
+            },
             export_format="csv",
             page_size=20,
             style_table={
@@ -326,7 +328,7 @@ def create_timeline(selected_columns: list, dark_mode: bool) -> go.Figure:
                 )
     timeline_figure.update_layout(
         title="Membership Trends Timeline",
-		yaxis_title="Members"
+        yaxis_title="Members"
     )
     if not dark_mode:
         timeline_figure["layout"]["template"] = pio.templates["journal"]
@@ -406,18 +408,18 @@ def calculate_retention_rate(df: pd.DataFrame, df_compare: pd.DataFrame, dark_mo
             mode="number+delta",
             value=rate,
             delta={
-				"position": "top",
-				"reference": rate_compare,
-				"valueformat": ".2"
-			},
+                "position": "top",
+                "reference": rate_compare,
+                "valueformat": ".2"
+            },
             number={"suffix": "%"},
         )
 
     fig = go.Figure(
         data=indicator,
-		layout={
-			"title": "Retention Rate (MIGS / Constitutional)"
-		}
+        layout={
+            "title": "Retention Rate (MIGS / Constitutional)"
+        }
     )
 
     if not dark_mode:

--- a/membership_dashboard.py
+++ b/membership_dashboard.py
@@ -58,18 +58,27 @@ sidebar_header = dbc.Row(
             align="center",
         ),
         dbc.Col(
-            html.Span(
-                [
-                    # dbc.Label(className="fa fa-sun", html_for="color-mode-switch"),
-                    dbc.Switch(
-                        id="color-mode-switch",
-                        value=True,
-                        className="d-inline-block ms-1",
-                        persistence=True,
-                    ),
-                    dbc.Label(className="fa fa-moon", html_for="color-mode-switch"),
-                ]
-            ),
+            [
+                dbc.Row(
+                    [
+                        dbc.Col(
+                            dbc.Label(className="fa fa-sun", html_for="color-mode-switch")
+                        ),
+                        dbc.Col(
+                            dbc.Switch(
+                                id="color-mode-switch",
+                                value=True,
+                                className="d-inline-block ms-1",
+                                persistence=True,
+                            )
+                        ),
+                        dbc.Col(
+                            dbc.Label(className="fa fa-moon", html_for="color-mode-switch")
+                        ),
+                    ],
+                    className="g-0",
+                )
+            ],
             width="auto",
             align="center",
         ),
@@ -629,12 +638,15 @@ clientside_callback(
        return window.dash_clientside.no_update
     }
     """,
-    Output("color-mode-switch", "id"),
-    Input("color-mode-switch", "value"),
+    Output(component_id="color-mode-switch", component_property="id"),
+    Input(component_id="color-mode-switch", component_property="value"),
 )
 
 
-@app.callback(Output("page-content", "children"), [Input("url", "pathname")])
+@app.callback(
+    Output(component_id="page-content", component_property="children"),
+    Input(component_id="url", component_property="pathname"),
+)
 def render_page_content(pathname: str):
     """Display the correct page based on the user's navigation path."""
     if pathname == "/":
@@ -649,6 +661,7 @@ def render_page_content(pathname: str):
         return html.P(
             "Implementation of a map is planned: https://github.com/MaineDSA/MembershipDashboard/issues/8."
         )
+
     # If the user tries to reach a different page, return a 404 message
     return html.Div(
         [

--- a/membership_dashboard.py
+++ b/membership_dashboard.py
@@ -6,8 +6,7 @@ import plotly.graph_objects as go
 import dash_bootstrap_components as dbc
 from dash_bootstrap_templates import load_figure_template
 from dash import Dash, html, dash_table, dcc, callback, clientside_callback, Output, Input
-from scan_membership_lists import get_all_membership_lists, get_membership_list_metrics
-#from scan_membership_lists import scan_all_membership_lists, scan_membership_list_metrics
+from scan_membership_lists import get_membership_lists, get_membership_list_metrics
 
 
 # A list of colors for graphs.
@@ -28,8 +27,8 @@ COLORS = [
 ]
 
 
-memb_lists = get_all_membership_lists()
-memb_lists_metrics = get_membership_list_metrics()
+memb_lists = get_membership_lists()
+memb_lists_metrics = get_membership_list_metrics(memb_lists)
 
 
 # Initialize the app

--- a/membership_dashboard.py
+++ b/membership_dashboard.py
@@ -62,7 +62,9 @@ sidebar_header = dbc.Row(
                 dbc.Row(
                     [
                         dbc.Col(
-                            dbc.Label(className="fa fa-sun", html_for="color-mode-switch")
+                            dbc.Label(
+                                className="fa fa-sun", html_for="color-mode-switch"
+                            )
                         ),
                         dbc.Col(
                             dbc.Switch(
@@ -73,7 +75,9 @@ sidebar_header = dbc.Row(
                             )
                         ),
                         dbc.Col(
-                            dbc.Label(className="fa fa-moon", html_for="color-mode-switch")
+                            dbc.Label(
+                                className="fa fa-moon", html_for="color-mode-switch"
+                            )
                         ),
                     ],
                     className="g-0",
@@ -178,9 +182,7 @@ member_list_page = html.Div(
                 {"column_id": "first_name", "direction": "asc"},
             ],
             filter_action="native",
-            filter_options={
-                "case": "insensitive"
-            },
+            filter_options={"case": "insensitive"},
             export_format="csv",
             page_size=20,
             style_table={
@@ -336,8 +338,7 @@ def create_timeline(selected_columns: list, dark_mode: bool) -> go.Figure:
                     )
                 )
     timeline_figure.update_layout(
-        title="Membership Trends Timeline",
-        yaxis_title="Members"
+        title="Membership Trends Timeline", yaxis_title="Members"
     )
     if not dark_mode:
         timeline_figure["layout"]["template"] = pio.templates["journal"]
@@ -358,7 +359,10 @@ def create_list(date_selected: str, date_compare_selected: str) -> dict:
         df = (
             pd.concat([df, df_compare])
             .reset_index(drop=False)
-            .drop_duplicates(subset=["actionkit_id", "membership_status", "membership_type"], keep=False)
+            .drop_duplicates(
+                subset=["actionkit_id", "membership_status", "membership_type"],
+                keep=False,
+            )
             .drop_duplicates(subset=["actionkit_id"])
         )
     return df.to_dict("records")
@@ -416,19 +420,12 @@ def calculate_retention_rate(df: pd.DataFrame, df_compare: pd.DataFrame, dark_mo
         indicator = go.Indicator(
             mode="number+delta",
             value=rate,
-            delta={
-                "position": "top",
-                "reference": rate_compare,
-                "valueformat": ".2"
-            },
+            delta={"position": "top", "reference": rate_compare, "valueformat": ".2"},
             number={"suffix": "%"},
         )
 
     fig = go.Figure(
-        data=indicator,
-        layout={
-            "title": "Retention Rate (MIGS / Constitutional)"
-        }
+        data=indicator, layout={"title": "Retention Rate (MIGS / Constitutional)"}
     )
 
     if not dark_mode:

--- a/scan_membership_lists.py
+++ b/scan_membership_lists.py
@@ -12,10 +12,20 @@ from tqdm import tqdm
 MEMB_LIST_NAME = "maine_membership_list"
 
 
-memb_lists = {}
-"""Contains data organized as column:value pairs within a dict of membership list dates."""
-memb_lists_metrics = {}
-"""Contains data organized as date:value pairs within a dict of original columns names."""
+def get_membership_list_metrics(memb_lists: pd.DataFrame) -> dict:
+    """Scan memb_lists and calculate metrics."""
+    memb_lists_metrics = {}
+
+    print(f"Calculating metrics for {len(memb_lists)} membership lists")
+    for date_formatted, membership_list in memb_lists.items():
+        for column in membership_list.columns:
+            if column not in memb_lists_metrics:
+                memb_lists_metrics[column] = {}
+            memb_lists_metrics[column][date_formatted] = memb_lists[date_formatted][
+                column
+            ]
+
+    return memb_lists_metrics
 
 
 def membership_length(date: str, **kwargs) -> int:
@@ -25,9 +35,8 @@ def membership_length(date: str, **kwargs) -> int:
     )
 
 
-def data_cleaning(date_formatted: str) -> pd.DataFrame:
+def data_cleaning(df: pd.DataFrame, list_date: str) -> pd.DataFrame:
     """Clean and standardize dataframe according to specified rules."""
-    df = memb_lists[date_formatted].copy()  # To avoid modifying original data
     # Ensure column names are lowercase
     df.columns = df.columns.str.lower()
 
@@ -50,7 +59,7 @@ def data_cleaning(date_formatted: str) -> pd.DataFrame:
 
     # Apply the membership_length function to join_date
     df["membership_length"] = df["join_date"].apply(
-        membership_length, list_date=date_formatted
+        membership_length, list_date=list_date
     )
 
     # Standardize other columns
@@ -96,84 +105,71 @@ def data_cleaning(date_formatted: str) -> pd.DataFrame:
     return df
 
 
-def scan_membership_list(filename: str, filepath: str):
+def scan_membership_list(filename: str, filepath: str) -> pd.DataFrame:
     """Scan the requested membership list and add data to memb_lists."""
     date_from_name = pd.to_datetime(
         os.path.splitext(filename)[0].split("_")[3], format="%Y%m%d"
     ).date()
     if not date_from_name:
         print(f"No date detected in name of {filename}. Skipping file.")
-        return
+        return pd.DataFrame()
 
     with zipfile.ZipFile(filepath) as memb_list_zip:
         with memb_list_zip.open(f"{MEMB_LIST_NAME}.csv") as memb_list:
             # print(f"Loading data from {MEMB_LIST_NAME}.csv in {filename}.")
-            date_formatted = date_from_name.isoformat()
-
-            memb_lists[date_formatted] = pd.read_csv(memb_list, header=0)
-            memb_lists[date_formatted] = data_cleaning(date_formatted)
+            return pd.read_csv(memb_list, header=0)
 
 
-def scan_membership_list_metrics() -> (dict):
-    """Scan memb_lists and calculate metrics."""
-    print(f"Calculating metrics for {len(memb_lists)} membership lists")
-    for date_formatted, membership_list in tqdm(memb_lists.items(), unit='lists'):
-        for column in membership_list.columns:
-            if column not in memb_lists_metrics:
-                memb_lists_metrics[column] = {}
-            memb_lists_metrics[column][date_formatted] = memb_lists[date_formatted][
-                column
-            ]
-
-    # Pickle the scanned and calculated metrics
-    with open(f'{MEMB_LIST_NAME}_metrics.pkl', 'wb') as pickled_file:
-        pickle.dump(memb_lists_metrics, pickled_file)
-
-    return memb_lists_metrics
-
-
-def get_membership_list_metrics() -> (dict):
-    """Return the last calculated metrics."""
-    try:
-        with open(f'{MEMB_LIST_NAME}_metrics.pkl', 'rb') as pickled_file:
-            pickled_dict = pickle.load(pickled_file)
-            if len(pickled_dict) > 0:
-                return pickled_dict
-            return scan_membership_list_metrics()
-    except FileNotFoundError:
-        return scan_membership_list_metrics()
-
-    return {}
-
-
-def scan_all_membership_lists() -> (dict):
+def scan_all_membership_lists() -> dict:
     """Scan all zip files and call scan_membership_list on each."""
+    memb_lists = {}
+
     print(f"Scanning zipped membership lists in ./{MEMB_LIST_NAME}/.")
     files = sorted(
         glob.glob(os.path.join(MEMB_LIST_NAME, "**/*.zip"), recursive=True),
         reverse=True,
     )
-    for file in tqdm(files, unit='lists'):
-        scan_membership_list(os.path.basename(file), os.path.abspath(file))
+    for zip_file in tqdm(files, unit="lists"):
 
-    # Pickle the scanned and processed lists
-    with open(f'{MEMB_LIST_NAME}.pkl', 'wb') as pickled_file:
-        pickle.dump(memb_lists, pickled_file)
+        # Get date from each file name
+        filename = os.path.basename(zip_file)
+        date_from_name = pd.to_datetime(
+            os.path.splitext(filename)[0].split("_")[3], format="%Y%m%d"
+        ).date()
+        if not date_from_name:
+            print(f"No date detected in name of {filename}. Skipping file.")
+            continue
 
-    scan_membership_list_metrics()
+        # Save contents of each zip file into dict keyed to date
+        memb_lists[date_from_name.isoformat()] = scan_membership_list(filename, os.path.abspath(zip_file))
 
+    print(f"Found {len(memb_lists)} zipped membership lists.")
     return memb_lists
 
 
-def get_all_membership_lists() -> (dict):
+def get_pickled_dict() -> dict:
     """Return the last scanned membership lists."""
     try:
-        with open(f'{MEMB_LIST_NAME}.pkl', 'rb') as pickled_file:
+        with open(f"{MEMB_LIST_NAME}.pkl", "rb") as pickled_file:
             pickled_dict = pickle.load(pickled_file)
-            if len(pickled_dict) > 0:
-                return pickled_dict
-            return scan_all_membership_lists()
+            print(f"Found {len(pickled_dict)} pickled membership lists.")
+            return pickled_dict
     except FileNotFoundError:
-        return scan_all_membership_lists()
+        pass
 
     return {}
+
+def get_membership_lists() -> dict:
+    """Return all membership lists, preferring pickled lists for speed."""
+    memb_lists = scan_all_membership_lists()
+    pickled_lists = get_pickled_dict()
+    new_lists = {k: v for k, v in memb_lists.items() if k not in pickled_lists}
+    print(f"Found {len(new_lists)} new lists")
+    if len(new_lists) > 0:
+        new_lists = {k: data_cleaning(v, k) for k, v in tqdm(new_lists.items(), unit="lists")}
+    memb_lists = new_lists | pickled_lists
+
+    with open(f"{MEMB_LIST_NAME}.pkl", "wb") as pickled_file:
+        pickle.dump(memb_lists, pickled_file)
+
+    return memb_lists

--- a/scan_membership_lists.py
+++ b/scan_membership_lists.py
@@ -139,8 +139,7 @@ def get_membership_list_metrics() -> (dict):
             pickled_dict = pickle.load(pickled_file)
             if len(pickled_dict) > 0:
                 return pickled_dict
-            else:
-                return scan_membership_list_metrics()
+            return scan_membership_list_metrics()
     except FileNotFoundError:
         return scan_membership_list_metrics()
 
@@ -173,8 +172,7 @@ def get_all_membership_lists() -> (dict):
             pickled_dict = pickle.load(pickled_file)
             if len(pickled_dict) > 0:
                 return pickled_dict
-            else:
-                return scan_all_membership_lists()
+            return scan_all_membership_lists()
     except FileNotFoundError:
         return scan_all_membership_lists()
 


### PR DESCRIPTION
Scanning over 170 zip files and re-processing changes every time the server starts wastes a lot of development time and is annoying for users who want to quickly reference metrics/stats.
By using Python's data pickling functionality, we can re-load the last results instead of re-scanning on load.